### PR TITLE
Fix wrong sorting of Container Children

### DIFF
--- a/Classes/Hooks/DataHandler.php
+++ b/Classes/Hooks/DataHandler.php
@@ -9,10 +9,46 @@ namespace Team23\T23InlineContainer\Hooks;
  * LICENSE.txt file that was distributed with this source code.
  */
 
+use B13\Container\Domain\Factory\ContainerFactory;
+use B13\Container\Integrity\Database;
+use B13\Container\Tca\Registry;
+use Team23\T23InlineContainer\Integrity\Sorting;
 use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class DataHandler implements SingletonInterface
 {
+    /**
+     * @param $status
+     * @param $table
+     * @param $id
+     * @param $fieldArray
+     * @param \TYPO3\CMS\Core\DataHandling\DataHandler $pObj
+     * @return void
+     */
+    public function processDatamap_postProcessFieldArray($status, $table, $id, &$fieldArray, \TYPO3\CMS\Core\DataHandling\DataHandler &$pObj)
+    {
+        /**
+         * fix sorting of container inline elements
+         */
+        if (
+            $table === 'tt_content' &&
+            ($status === 'update' || $status === 'new') &&
+            (int) $pObj->checkValue_currentRecord['uid'] > 0 &&
+            (int) $pObj->checkValue_currentRecord['tx_t23inlinecontainer_elements'] > 0
+        ) {
+            $containerRecord = $pObj->checkValue_currentRecord;
+            $cType = $containerRecord['CType'];
+            $database = GeneralUtility::makeInstance(Database::class);
+            $registry = GeneralUtility::makeInstance(Registry::class);
+            $containerFactory = GeneralUtility::makeInstance(ContainerFactory::class);
+            $sorting = GeneralUtility::makeInstance(Sorting::class, $database, $registry, $containerFactory);
+            $sorting->runForSingleContainer($containerRecord, $cType);
+
+            // force update of parent element when new inline element is added
+            $fieldArray['tstamp'] = time() + 1;
+        }
+    }
 
     public function processCmdmap_preProcess($command, $table, $id, $value, $pObj, $pasteUpdate)
     {

--- a/Classes/Integrity/Sorting.php
+++ b/Classes/Integrity/Sorting.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Team23\T23InlineContainer\Integrity;
+
+class Sorting extends \B13\Container\Integrity\Sorting
+{
+    public function runForSingleContainer($containerRecord, $cType)
+    {
+        $columns = $this->tcaRegistry->getAvailableColumns($cType);
+        $colPosByCType[$cType] = [];
+        foreach ($columns as $column) {
+            $colPosByCType[$cType][] = $column['colPos'];
+        }
+        $this->unsetContentDefenderConfiguration($cType);
+        $this->fixChildrenSorting([$containerRecord], $colPosByCType, false);
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -10,6 +10,7 @@ defined('TYPO3') || die();
  */
 
 $GLOBALS ['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processCmdmapClass']['tx-t23inlinecontainer'] = 'Team23\T23InlineContainer\Hooks\DataHandler';
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass']['tx-t23inlinecontainer'] = 'Team23\T23InlineContainer\Hooks\DataHandler';
 
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord'][\Team23\T23InlineContainer\Backend\FormDataProvider\ContainerChildrenFormDataProvider::class] = [
     'depends' => [


### PR DESCRIPTION
This PR should fix #7. In the current state, the sorting is correct on second save.