### PR TITLE
TYPO3 v13 compatibility

### DIFF
--- a/Classes/Hooks/DataHandler.php
+++ b/Classes/Hooks/DataHandler.php
@@ -41,14 +41,14 @@ class DataHandler implements SingletonInterface
         }
     }
 
-    public function processCmdmap_preProcess($command, $table, $id, $value, $pObj, $pasteUpdate)
+    public function processCmdmap_preProcess($command, $table, $id, $value, $pObj, $pasteUpdate): void
     {
         if (in_array($command, ['copy', 'localize']) && $table === 'tt_content') {
             $GLOBALS['TCA']['tt_content']['columns']['tx_t23inlinecontainer_elements']['config']['type'] = 'none';
         }
     }
 
-    public function processCmdmap_postProcess($command, $table, $id, $value, $pObj, $pasteUpdate, $pasteDatamap)
+    public function processCmdmap_postProcess($command, $table, $id, $value, $pObj, $pasteUpdate, $pasteDatamap): void
     {
         if (in_array($command, ['copy', 'localize']) && $table === 'tt_content') {
             $GLOBALS['TCA']['tt_content']['columns']['tx_t23inlinecontainer_elements']['config']['type'] = 'tx_t23inlinecontainer_elements';
@@ -60,7 +60,7 @@ class DataHandler implements SingletonInterface
      * @param \TYPO3\CMS\Core\DataHandling\DataHandler $dataHandler
      * @return void
      */
-    public function processDatamap_afterAllOperations(\TYPO3\CMS\Core\DataHandling\DataHandler $dataHandler)
+    public function processDatamap_afterAllOperations(\TYPO3\CMS\Core\DataHandling\DataHandler $dataHandler): void
     {
         // Make sure that container sorting is only update once per container element
         // => Only run sorting update after all operations have been finished

--- a/Classes/Integrity/Sorting.php
+++ b/Classes/Integrity/Sorting.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class Sorting extends \B13\Container\Integrity\Sorting
 {
-    public function runForSingleContainer($containerRecord, $cType)
+    public function runForSingleContainer($containerRecord, $cType): void
     {
         $columns = $this->tcaRegistry->getAvailableColumns($cType);
         $colPosByCType[$cType] = [];

--- a/Classes/Listener/AddFieldToAllContainers.php
+++ b/Classes/Listener/AddFieldToAllContainers.php
@@ -16,7 +16,7 @@ use TYPO3\CMS\Core\Configuration\Event\AfterTcaCompilationEvent;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class AddFieldToAllContainers {
-    public function __invoke(AfterTcaCompilationEvent $event)
+    public function __invoke(AfterTcaCompilationEvent $event): void
     {
         $containerRegistry = GeneralUtility::makeInstance(\B13\Container\Tca\Registry::class);
 

--- a/Classes/Listener/ContentUsedOnPage.php
+++ b/Classes/Listener/ContentUsedOnPage.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Team23\T23InlineContainer\Listener;
+
+use B13\Container\Domain\Factory\Exception;
+use B13\Container\Domain\Factory\PageView\Backend\ContainerFactory;
+use B13\Container\Tca\Registry;
+use TYPO3\CMS\Backend\View\Event\IsContentUsedOnPageLayoutEvent;
+
+final class ContentUsedOnPage
+{
+    protected Registry $tcaRegistry;
+    protected ContainerFactory $containerFactory;
+
+    public function __construct(ContainerFactory $containerFactory, Registry $tcaRegistry)
+    {
+        $this->containerFactory = $containerFactory;
+        $this->tcaRegistry = $tcaRegistry;
+    }
+
+    public function __invoke(IsContentUsedOnPageLayoutEvent $event): void
+    {
+        $record = $event->getRecord();
+        if ($record['tx_container_parent'] > 0) {
+            try {
+                $container = $this->containerFactory->buildContainer((int)$record['tx_container_parent']);
+                $columns = $this->tcaRegistry->getAvailableColumns($container->getCType());
+                foreach ($columns as $column) {
+                    if ($column['colPos'] === (int)$record['colPos']) {
+                        if ($record['sys_language_uid'] > 0 && $container->isConnectedMode()) {
+                            $used = ($container->hasChildInColPos((int)$record['colPos'], (int)$record['l18n_parent'])
+                                || $container->hasChildInColPos((int)$record['colPos'], (int)$record['uid']));
+                            $event->setUsed($used);
+                            return;
+                        }
+                        $used = $container->hasChildInColPos((int)$record['colPos'], (int)$record['uid']);
+                        $event->setUsed($used);
+                        return;
+                    }
+                }
+            } catch (Exception $e) {
+            }
+        }
+    }
+}

--- a/Classes/Listener/ContentUsedOnPage.php
+++ b/Classes/Listener/ContentUsedOnPage.php
@@ -30,6 +30,11 @@ final class ContentUsedOnPage
                 foreach ($columns as $column) {
                     if ($column['colPos'] === (int)$record['colPos']) {
                         if ($record['sys_language_uid'] > 0 && $container->isConnectedMode()) {
+
+                            /*
+                            Prevents displaying of "Unused elements detected on this page" in the Page module in Backend when
+                            container element is translated in "Connected Mode"
+                            */
                             $used = ($container->hasChildInColPos((int)$record['colPos'], (int)$record['l18n_parent'])
                                 || $container->hasChildInColPos((int)$record['colPos'], (int)$record['uid']));
                             $event->setUsed($used);

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -16,3 +16,9 @@ services:
       - name: event.listener
         identifier: 'addFieldToAllContainers'
         event: TYPO3\CMS\Core\Configuration\Event\AfterTcaCompilationEvent
+
+  Team23\T23InlineContainer\Listener\ContentUsedOnPage:
+    tags:
+      - name: event.listener
+        identifier: 't23-inline-container-content-used-on-page'
+        after: 'tx-container-content-used-on-page'

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -27,7 +27,6 @@ call_user_func(function ($extKey, $table) {
                         'levelLinksPosition' => 'bottom',
                         'useSortable' => true,
                         'showPossibleLocalizationRecords' => true,
-                        'showRemovedLocalizationRecords' => true,
                         'showAllLocalizationLink' => true,
                         'showSynchronizationLink' => true,
                         'enabledControls' => [

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "homepage": "https://www.team23.de/",
     "license": "GPL-2.0-or-later",
     "require": {
-        "typo3/cms-core": "^11.5 || ^12.4",
-        "b13/container": "^2.3.1"
+        "typo3/cms-core": "^12.4 || ^13.4",
+        "b13/container": "^2.3 || ^3.1"
     },
     "suggest": {
         "georgringer/news": "Most usefull application of this extension."

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -15,17 +15,16 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => 'dreier@team23.de',
     'author_company' => 'TEAM23',
     'state' => 'beta',
-    'clearCacheOnLoad' => true,
-    'version' => '0.0.13',
+    'version' => '1.0.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '11.0.0-12.9.99',
-            'container' => '2.3.1-2.9.99',
+            'typo3' => '12.4.0-13.4.99',
+            'container' => '2.3.1-3.9.99',
         ],
         'conflicts' => [
         ],
         'suggests' => [
-            'news' => '9.0.0-10.9.9'
+            'news' => '9.0.0-12.9.9'
         ],
     ],
 ];


### PR DESCRIPTION
### What?
I updated the extension and made it compatible with TYPO3 v13 and PHP v8.3

### Why?
The Extension **t23_inline_container** is a useful extension, but has no version compatible for TYPO3 v13.
So I updated the extension so that its users can continue using and enjoying it with TYPO3 v13.

### How?
- Setting of return types for functions with no return type specified.
- Implementing an event Listener for the '**IsContentUsedOnPageLayoutEvent'** event to prevent the displaying of the
'**Unused elements detected on this page**' message being displayed in the Page Module in the TYPO3 Backend when a Container Content Element with children is localized in the 'Connected Mode'.
- Remove '**showRemovedLocalizationRecords**' TCA option which is no longer used.

### Testing
Tested on TYPO3 v12 and TYPO3 v13
